### PR TITLE
Fix issue around adding incorrect KnownHost

### DIFF
--- a/hosts.go
+++ b/hosts.go
@@ -98,13 +98,13 @@ func AddKnownHost(host string, remote net.Addr, key ssh.PublicKey, knownFile str
 
 	remoteNormalized := knownhosts.Normalize(remote.String())
 	hostNormalized := knownhosts.Normalize(host)
+	addresses := []string{remoteNormalized}
 
-	knownHost := hostNormalized
-	if hostNormalized == remoteNormalized {
-		knownHost = remoteNormalized
+	if hostNormalized != remoteNormalized {
+		addresses = append(addresses, hostNormalized)
 	}
 
-	_, err = f.WriteString(knownhosts.Line([]string{knownHost}, key) + "\n")
+	_, err = f.WriteString(knownhosts.Line(addresses, key) + "\n")
 
 	return err
 }

--- a/hosts.go
+++ b/hosts.go
@@ -96,7 +96,13 @@ func AddKnownHost(host string, remote net.Addr, key ssh.PublicKey, knownFile str
 
 	defer f.Close()
 
-	knownHost := knownhosts.Normalize(remote.String())
+	remoteNormalized := knownhosts.Normalize(remote.String())
+	hostNormalized := knownhosts.Normalize(host)
+
+	knownHost := hostNormalized
+	if hostNormalized == remoteNormalized {
+		knownHost = remoteNormalized
+	}
 
 	_, err = f.WriteString(knownhosts.Line([]string{knownHost}, key) + "\n")
 


### PR DESCRIPTION
Host should always be check against remote as it could be a name or an IP. but if the name is passed then it won t match the remote IP and therefore saved the incorrect entry in the known host