### PR TITLE
context support for command cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ You can find the docs at [go docs](https://pkg.go.dev/github.com/melbahja/goph).
 - Supports connections with **ssh agent** (Unix systems only).
 - Supports adding new hosts to **known_hosts file**.
 - Supports **file system operations** like: `Open, Create, Chmod...`
+- Supports **context.Context** for command cancellation.
 
 ## 📄&nbsp; Usage
 
@@ -119,6 +120,14 @@ err := client.Download("/path/to/remote/file", "/path/to/local/file")
 out, err := client.Run("bash -c 'printenv'")
 ```
 
+#### ☛ Execute Bash Command with timeout:
+```go
+context, cancel := context.WithTimeout(ctx, time.Second)
+defer cancel()
+// will send SIGINT and return error after 1 second
+out, err := client.RunContext(ctx, "sleep 5")
+```
+
 #### ☛ Execute Bash Command With Env Variables:
 ```go
 out, err := client.Run(`env MYVAR="MY VALUE" bash -c 'echo $MYVAR;'`)
@@ -131,6 +140,9 @@ out, err := client.Run(`env MYVAR="MY VALUE" bash -c 'echo $MYVAR;'`)
 ```go
 // Get new `Goph.Cmd`
 cmd, err := client.Command("ls", "-alh", "/tmp")
+
+// or with context:
+// cmd, err := client.CommandContext(ctx, "ls", "-alh", "/tmp")
 
 if err != nil {
 	// handle the error!

--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@
 package goph
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -106,6 +107,16 @@ func (c Client) Run(cmd string) ([]byte, error) {
 	return sess.CombinedOutput(cmd)
 }
 
+// Run starts a new SSH session with context and runs the cmd. It returns CombinedOutput and err if any.
+func (c Client) RunContext(ctx context.Context, name string) ([]byte, error) {
+	cmd, err := c.CommandContext(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	return cmd.CombinedOutput()
+}
+
 // Command returns new Cmd and error if any.
 func (c Client) Command(name string, args ...string) (*Cmd, error) {
 
@@ -122,7 +133,20 @@ func (c Client) Command(name string, args ...string) (*Cmd, error) {
 		Path:    name,
 		Args:    args,
 		Session: sess,
+		Context: context.Background(),
 	}, nil
+}
+
+// Command returns new Cmd with context and error, if any.
+func (c Client) CommandContext(ctx context.Context, name string, args ...string) (*Cmd, error) {
+	cmd, err := c.Command(name, args...)
+	if err != nil {
+		return cmd, err
+	}
+
+	cmd.Context = ctx
+
+	return cmd, nil
 }
 
 // NewSftp returns new sftp client and error if any.


### PR DESCRIPTION
It is convenient to be able to cancel a command with `context`.

A standard go library already has `exec.CommandContext`, and I just used the same approach here.

When the context is cancelled, a `SIGINT` signal is sent to the session. I also considered making a specific signal configurable (because interrupt asks nicely and isn't always reliable). But for now this seems to work fine.

The previous API without context still works fine, so no compatibility is broken.

