### PR TITLE
enable connection using raw private key without file path

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -37,6 +37,17 @@ func Key(prvFile string, passphrase string) (Auth, error) {
 	}, nil
 }
 
+func RawKey(privateKey string, passphrase string) (Auth, error) {
+	signer, err := GetSignerForRawKey([]byte(privateKey), passphrase)
+	if err != nil {
+		return nil, err
+	}
+
+	return Auth{
+		ssh.PublicKeys(signer),
+	}, nil
+}
+
 // HasAgent checks if ssh agent exists.
 func HasAgent() bool {
 	return os.Getenv("SSH_AUTH_SOCK") != ""
@@ -62,6 +73,30 @@ func GetSigner(prvFile string, passphrase string) (ssh.Signer, error) {
 	)
 
 	privateKey, err := ioutil.ReadFile(prvFile)
+
+	if err != nil {
+
+		return nil, err
+
+	} else if passphrase != "" {
+
+		signer, err = ssh.ParsePrivateKeyWithPassphrase(privateKey, []byte(passphrase))
+
+	} else {
+
+		signer, err = ssh.ParsePrivateKey(privateKey)
+	}
+
+	return signer, err
+}
+
+// GetSigner returns ssh signer from private key file.
+func GetSignerForRawKey(privateKey []byte, passphrase string) (ssh.Signer, error) {
+
+	var (
+		err    error
+		signer ssh.Signer
+	)
 
 	if err != nil {
 

--- a/auth.go
+++ b/auth.go
@@ -90,7 +90,7 @@ func GetSigner(prvFile string, passphrase string) (ssh.Signer, error) {
 	return signer, err
 }
 
-// GetSigner returns ssh signer from private key file.
+// GetSignerForRawKey returns ssh signer from private key file.
 func GetSignerForRawKey(privateKey []byte, passphrase string) (ssh.Signer, error) {
 
 	var (
@@ -98,11 +98,7 @@ func GetSignerForRawKey(privateKey []byte, passphrase string) (ssh.Signer, error
 		signer ssh.Signer
 	)
 
-	if err != nil {
-
-		return nil, err
-
-	} else if passphrase != "" {
+	if passphrase != "" {
 
 		signer, err = ssh.ParsePrivateKeyWithPassphrase(privateKey, []byte(passphrase))
 


### PR DESCRIPTION
Thanks for this awesome library,
I have a problem currently with the connection with private key,

I have a private key with an actual content exist int the memory "the private key is not stored on the file system"
as the following:
```
-----BEGIN RSA PRIVATE KEY-----
key content
-----END RSA PRIVATE KEY-----
```

how can I use that private key to connect to the server, because it doesn't work with the following:

```go
	authKey, _ := goph.Key(serverData.SshPrivateKey, "")
	fmt.Sprintf("------------- my dd %", authKey)
	goph.Key()
	client, err := goph.New(serverData.SshRootUsername, DEFAULT_SERVER_IP, authKey)
```